### PR TITLE
Upgrade with latest yaml files to be compatible with ESPHome

### DIFF
--- a/home_assistant/common/mitsubishi_cn105_config.yaml
+++ b/home_assistant/common/mitsubishi_cn105_config.yaml
@@ -94,6 +94,7 @@ logger:
     CYCLE: WARN
     Decoder : WARN
     EVT_SETS : WARN
+    FUNCTIONS: WARN
     Header : WARN
     light: WARN
     MQTT : WARN
@@ -107,3 +108,4 @@ logger:
     WIFI : DEBUG
     WRITE : WARN
     WRITE_SETTINGS : WARN
+    

--- a/home_assistant/common/mitsubishi_cn105_device_base.yaml
+++ b/home_assistant/common/mitsubishi_cn105_device_base.yaml
@@ -7,31 +7,31 @@
 # This package requires the following substitutions to be defined:
 #
 #  - Identification
-#        name                    -> ESPHome name 
-#        hp_name                 -> Climate name to use
-#        hp_id                   -> Climate device ID - default hp_id
-#        hp_F_compatibility      -> Use internal table for better temp compatibility - default true
-#        hp_update_interval      -> Interval between updates - split mini dependent - default 1.5s
+#        name                     -> ESPHome name 
+#        hp_name                  -> Climate name to use
+#        hp_id                    -> Climate device ID - default hp_id
+#        hp_F_compatibility       -> Use internal table for better temp compatibility - default standard
+#        hp_update_interval       -> Interval between updates - split mini dependent - default 1.5s
 #
 #  - Device Setup
-#        cn105_tx_pin            -> TX pin number for CN105 UART - default GPIO1
-#        cn105_rx_pin            -> RX pin number for CN105 UART - default GPIO2
-#        i2c_scl_pin             -> SCL pin number for i2c bus   - default GPIO22
-#        i2c_sda_pin             -> SDA pin number for i2c bus   - default GPIO21
-#        i2c_scan_bus            -> boolean to scan bus or not.  - default false
-#        status_light_ctrl_pin   -> Pin number for RMT LED Strip - default GPIO8
-#        status_light_brightness -> Whole number percentage (0-100) for led brightness - default 25
+#        cn105_tx_pin             -> TX pin number for CN105 UART - default GPIO1
+#        cn105_rx_pin             -> RX pin number for CN105 UART - default GPIO2
+#        i2c_scl_pin              -> SCL pin number for i2c bus   - default GPIO22
+#        i2c_sda_pin              -> SDA pin number for i2c bus   - default GPIO21
+#        i2c_scan_bus             -> boolean to scan bus or not.  - default false
+#        status_light_ctrl_pin    -> Pin number for RMT LED Strip - default GPIO8
+#        status_light_brightness  -> Whole number percentage (0-100) for led brightness - default 25
 #
 #  - Controlling constants
-#        rts_refresh_timeout.   -> number of seconds with no update to trigger rta refresh
+#        rts_refresh_timeout      -> number of seconds with no update to trigger rta refresh
 #  - Scripts
-#        reevaluate_remote_temp. -> Script to recalculate remote temperature.  Needed on MODE change.
+#        reevaluate_remote_temp   -> Script to recalculate remote temperature.  Needed on MODE change.
 
 substitutions:
   # Climate Device ID & control settings
   hp_id: hp_id
   hp_name: None
-  hp_F_compatibility: true
+  hp_F_compatibility: standard
   hp_update_interval: 1.5s
   
   # HP Uart GPIO pin selection
@@ -51,10 +51,12 @@ substitutions:
 # Retrieve mitsubishi components
 external_components:
   - source: github://echavet/MitsubishiCN105ESPHome
+  #- source: github://GioMez/MitsubishiCN105ESPHome
 
 # Setup boot initialization
 esphome:
   on_boot: 
+    priority: 100
     then:
       # Initialize the status light - red means not initialized
       - light.turn_on:
@@ -260,7 +262,7 @@ climate:
         current_temperature: 0.5
     # Fahrenheit compatibility mode - uses Mitsubishi's "custom" unit conversions, set to
     # "true" for better support of Fahrenheit units in HomeAssistant
-    fahrenheit_compatibility: ${hp_F_compatibility}
+    fahrenheit_compatibility: "${hp_F_compatibility}"
     # Timeout and communication settings
     remote_temperature_timeout: 60min
     update_interval: ${hp_update_interval}

--- a/home_assistant/common/mitsubishi_cn105_device_base.yaml
+++ b/home_assistant/common/mitsubishi_cn105_device_base.yaml
@@ -98,7 +98,9 @@ light:
     id: status_led
     name: "Status Led"
     internal: true
-    pin: ${status_light_ctrl_pin}
+    pin:
+      number: ${status_light_ctrl_pin}
+      ignore_strapping_warning: true
     num_leds: 1
     rgb_order: RGB
     chipset: WS2812

--- a/home_assistant/examples/cn105-tester.yaml
+++ b/home_assistant/examples/cn105-tester.yaml
@@ -77,6 +77,41 @@
 #      where CMD is the letter you type on the keyboard.  Only the header is printed until you manually enter a CMD.
 #      Any other command entered will display a message about unknown command.
 #
+#  ------------------------- FIRMWARE UPDATE AFTER TEST -------------------------
+#
+#  There are two way to re-flash the after testing.  In both situations you need a Yaml file that contains  
+#  sufficient configuration to boot the device on your WiFi network and then can be used to upload the final CN105
+#  firmware.  The easiest way to do this is to use the ESPHome Builder -> "+ New Device" button to generate a 
+#  default configuration.  This will be sufficient to bring the device on-line in order to then upgrade to the 
+#  CN105 firmware.  More importantly, this will also generate the API key and OTA Password which are needed to
+#  connect to Home Assistant and support Over-The-Air updating of the firmware.  It is beyond the scope of this
+#  document to show how to generate these two items using other tools.
+#
+#  To update the device from Test firmware to final CN105 firmware you need to do the following steps:
+#
+#    1.  Using Chrome (the browser must support serial device attachment which most do not), navigate to 
+#        ESPHome Builder running within Home Assistant.  If you haven't setup ESPHome Builder within Home
+#        Assistant you'll need to go and do that now (this is outside of the scope of this document).
+#    2.  Add a new device via ESPHome Builder -> "+ New Device", select "New Device Setup" and enter an 
+#        appropriate name.  Typically this would be some kind of room designation - I preface it with "midu-"
+#        which denotes it is a Mitsubishi Electric Indoor Unit (this designation is from Mitsubishi).  For
+#        example:  "midu-guest-bedroom" to denote it is a Mitsubishi Electric Indoor Unit in the guest bedroom.
+#    3.  You will now be prompted to connect the hardware - press "SKIP THIS STEP" - we will connec the hardware
+#        at a later point in time.
+#    4.  Select "ESP32-C6" which is the CPU type in the microcontroller.  You will be shown the Encryption Key, press
+#        SKIP - the key will be stored in the configuration file.
+#
+#  At this point you have a basic configuration that contains all of the generated passwords and keys you
+#  will need.  We can now copy all of this information into the ESPBuilder SECRETS as follows:
+#
+#    1.  Press the EDIT button on the device you just created (it should show as OFFLINE).
+#    2.  Using a seperate window, select SECRETS in ESPHome Builder.  You will need to add the following
+#        key/values to SECRETS (this assumes you don't already have some of these):
+#           wifi_iot_ssid: "<the WiFi SSID you want the device to use>"
+#           wifi_iot_password: "<the WiFi password>"
+#           api_key_<midu-name>: "<api_key from #1>"
+#           ota_key_<midu-name>: "<ota_password from #1>"
+
 substitutions:
   wifi_ssid:     !secret wifi_iot_ssid
   wifi_password: !secret wifi_iot_password

--- a/pcb_assembly/WF-2/README.md
+++ b/pcb_assembly/WF-2/README.md
@@ -11,7 +11,6 @@ A reminder of the module:
 Remember the CN105 wire harness provided with the WF-2 is not compatible with the connector on the WF-1 without an adapter cable.  Please ensure you select the correct version of this project to ensure connector compatibility.
 
 ## Fabrication
-<html><span style="color:red; font-weight:bold;">PCB QUALIFICATION UNDERWAY<BR><ul><li>THIS BOARD HAS NOT YET BEEN FULLY TESTED<LI>PLEASE WAIT BEFORE FABRICATING THIS PCB<LI>EXPECTED COMPLETION: 02-15-2026</UL></span></html>
 
 PCB Manufacturing can be accomplished using whichever fabricator you wish.  For convenience, a [PCBWay](https://www.pcbway.com/project/shareproject/Mitsubishi_ESPHome_CN105_Microcontroller_PAC_USWHS002_WF_2_plug_compatible_8670e686.html) 
 project has been created that makes creating the PCB basically one click using PCBWay as the fabricator.   This option allows you to either create PCBs that you assemble using the parts below, or have the boards fully assembled so you just program and plugin.  You can also allow download of all gerber files, etc. in case you want to use a different vendor. 


### PR DESCRIPTION
This version maintains compatibility with ESPHome version 2026.1.x and later.  Slight changes to parameter values (quotes now required, etc) resulted in build failures.